### PR TITLE
Update for hyper 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ futures           = "0.1"
 http              = "0.1"
 hyper             = "0.12"
 mime              = "0.3"
-rand              = "0.3"
+rand              = "0.5"
 tokio             = "0.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ documentation     = "https://docs.rs/hyper-multipart-rfc7578"
 repository        = "https://github.com/ferristseng/rust-hyper-multipart-rfc7578"
 keywords          = ["hyper", "multipart", "form", "http"]
 categories        = ["asynchronous", "web-programming"]
-version           = "0.1.0-alpha3"
+version           = "0.2.0-alpha1"
 readme            = "README.md"
 license           = "MIT OR Apache-2.0"
 
@@ -16,9 +16,11 @@ travis-ci         = { repository = "ferristseng/rust-hyper-multipart-rfc7578" }
 [dependencies]
 bytes             = "0.4"
 futures           = "0.1"
-hyper             = "0.11"
+http              = "0.1"
+hyper             = "0.12"
+mime              = "0.3"
 rand              = "0.3"
-tokio-core        = "0.1"
+tokio             = "0.1"
 
 [dev-dependencies]
-hyper-tls         = "0.1"
+hyper-tls         = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ http              = "0.1"
 hyper             = "0.12"
 mime              = "0.3"
 rand              = "0.5"
-tokio             = "0.1"
 
 [dev-dependencies]
 hyper-tls         = "0.2"
+tokio             = "0.1"

--- a/src/client_.rs
+++ b/src/client_.rs
@@ -13,7 +13,7 @@ use http::{
 };
 use hyper;
 use mime::{self, Mime};
-use rand::{self, Rng};
+use rand::{distributions::Alphanumeric, rngs::SmallRng, FromEntropy, Rng};
 use std::borrow::Borrow;
 use std::{
     fmt::Display, fs::File, io::{self, Cursor, Read, Write}, iter::{FromIterator, Peekable},
@@ -621,8 +621,8 @@ impl BoundaryGenerator for RandomAsciiGenerator {
     /// Creates a boundary of 6 ascii characters.
     ///
     fn generate_boundary() -> String {
-        let mut rng = rand::weak_rng();
-        let ascii = rng.gen_ascii_chars();
+        let mut rng = SmallRng::from_entropy();
+        let ascii = rng.sample_iter(&Alphanumeric);
 
         String::from_iter(ascii.take(6))
     }

--- a/src/client_.rs
+++ b/src/client_.rs
@@ -85,9 +85,9 @@ impl Body {
         W: Write,
     {
         write_crlf(write)?;
-        write.write_all(&part.content_type.as_bytes())?;
+        write.write_all(&format!("Content-Type: {}", part.content_type).as_bytes())?;
         write_crlf(write)?;
-        write.write_all(&part.content_disposition.as_bytes())?;
+        write.write_all(&format!("Content-Disposition: {}", part.content_disposition).as_bytes())?;
         write_crlf(write)?;
         write_crlf(write)
     }
@@ -530,18 +530,12 @@ impl Part {
             disposition_params.push(format!("filename=\"{}\"", filename));
         }
 
-        let content_type = format!(
-            "Content-Type: {}",
-            mime.unwrap_or_else(|| inner.default_content_type())
-        );
+        let content_type = format!("{}", mime.unwrap_or_else(|| inner.default_content_type()));
 
         Part {
             inner: inner,
             content_type: content_type,
-            content_disposition: format!(
-                "Content-Disposition: form-data; {}",
-                disposition_params.join("; ")
-            ),
+            content_disposition: format!("form-data; {}", disposition_params.join("; ")),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,8 +29,8 @@ impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
             Error::HeaderWrite(_) => "Error writing headers",
-            Error::BoundaryWrite(_) => "Error writing boundary: {}",
-            Error::ContentRead(_) => "Error reading content: {}",
+            Error::BoundaryWrite(_) => "Error writing boundary",
+            Error::ContentRead(_) => "Error reading content",
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,44 @@
+// Copyright 2017 rust-hyper-multipart-rfc7578 Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+//
+
+use std::{error::Error as StdError, fmt, io::Error as IoError};
+
+#[derive(Debug)]
+pub enum Error {
+    HeaderWrite(IoError),
+    BoundaryWrite(IoError),
+    ContentRead(IoError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HeaderWrite(ref e) => write!(f, "Error writing headers: {}", e),
+            Error::BoundaryWrite(ref e) => write!(f, "Error writing boundary: {}", e),
+            Error::ContentRead(ref e) => write!(f, "Error reading content: {}", e),
+        }
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HeaderWrite(_) => "Error writing headers",
+            Error::BoundaryWrite(_) => "Error writing boundary: {}",
+            Error::ContentRead(_) => "Error reading content: {}",
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match *self {
+            Error::HeaderWrite(ref e) => Some(e),
+            Error::BoundaryWrite(ref e) => Some(e),
+            Error::ContentRead(ref e) => Some(e),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,139 +29,44 @@
 //! data structure (see the documentation for more detailed examples):
 //!
 //! ```rust
+//! # extern crate futures;
 //! # extern crate hyper;
 //! # extern crate hyper_multipart_rfc7578;
-//! # extern crate tokio_core;
+//! # extern crate tokio;
 //!
-//! use hyper::{Method, Request};
-//! use hyper::client::Client;
+//! use futures::Future;
+//! use hyper::{Method, Request, Client};
 //! use hyper_multipart_rfc7578::client::{self, multipart};
-//! use tokio_core::reactor::{Core, Handle};
 //!
 //! # fn main() {
-//! let mut core = Core::new().unwrap();
-//! let client: Client<_, multipart::Body> = client::create(&core.handle());
-//! let mut req = Request::new(Method::Get, "http://localhost/upload".parse().unwrap());
+//! let client = Client::new();
+//! let mut req_builder = Request::get("http://localhost/upload");
 //! let mut form = multipart::Form::default();
 //!
 //! form.add_text("test", "Hello World");
-//! form.set_body(&mut req);
+//! let req = form.set_body(&mut req_builder).unwrap();
 //!
-//! core.run(client.request(req));
+//! tokio::run(client.request(req).map(|_| ()).map_err(|_| ()));
 //! # }
 //! ```
 //!
 extern crate bytes;
 extern crate futures;
+extern crate http;
 extern crate hyper;
+extern crate mime;
 extern crate rand;
-extern crate tokio_core;
 
 mod client_;
+mod error;
 
-/// # Multipart RFC 7578 - Client
-///
-/// This module contains code related to making requests with a
-/// multipart/form body.
-///
-/// All data structures related to constructing a multipart/form body
-/// are in the submodule [`multipart`](/hyper_multipart_rfc7578/client/index.html).
-///
-/// This module contains a helper method to build a hyper client that can
-/// send a multipart body. [See](/hyper_multipart_rfc7578/client/fn.create.html).
-///
-/// # Examples
-///
-/// The most basic scenario would be creating a client with the provided
-/// function.
-///
-/// ```
-/// # extern crate hyper;
-/// # extern crate hyper_multipart_rfc7578;
-/// # extern crate tokio_core;
-/// #
-/// use hyper::{Method, Request};
-/// use hyper::client::Client;
-/// use hyper_multipart_rfc7578::client::{self, multipart};
-/// use tokio_core::reactor::{Core, Handle};
-///
-/// # fn main() {
-/// let mut core = Core::new().unwrap();
-/// let client: Client<_, multipart::Body> = client::create(&core.handle());
-/// let mut req = Request::new(Method::Get, "http://localhost/upload".parse().unwrap());
-/// let mut form = multipart::Form::default();
-///
-/// form.add_text("test", "Hello World");
-/// form.set_body(&mut req);
-///
-/// core.run(client.request(req));
-/// # }
-/// ```
-///
-/// You can also manually create a hyper client with a different connector,
-/// or different configuration using hyper's `Config` object.
-///
-/// ```
-/// # extern crate hyper;
-/// # extern crate hyper_multipart_rfc7578;
-/// # extern crate hyper_tls;
-/// # extern crate tokio_core;
-/// #
-/// use hyper::{Method, Request};
-/// use hyper::client::{Client, Config};
-/// use hyper_multipart_rfc7578::client::multipart;
-/// use hyper_tls::HttpsConnector;
-/// use tokio_core::reactor::{Core, Handle};
-///
-/// # fn main() {
-/// let mut core = Core::new().unwrap();
-/// let client: Client<HttpsConnector<_>, multipart::Body> =
-///     Config::default()
-///         .body::<multipart::Body>()
-///         .connector(HttpsConnector::new(2, &core.handle()).unwrap())
-///         .keep_alive(true)
-///         .build(&core.handle());
-/// let mut req = Request::new(Method::Get, "http://localhost/upload".parse().unwrap());
-/// let mut form = multipart::Form::default();
-///
-/// form.add_text("test", "Hello World");
-/// form.set_body(&mut req);
-///
-/// core.run(client.request(req));
-/// # }
-/// ```
-///
 pub mod client {
+    pub use error::Error;
+
     /// This module contains data structures for building a multipart/form
     /// body to send a server.
     ///
     pub mod multipart {
         pub use client_::{Body, BoundaryGenerator, Form, Part};
-    }
-
-    use hyper::client::{Client, Config, HttpConnector};
-    use tokio_core::reactor::Handle;
-
-    /// Creates a hyper client with a multipart body.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # extern crate hyper;
-    /// # extern crate hyper_multipart_rfc7578;
-    /// # extern crate tokio_core;
-    /// #
-    /// use hyper_multipart_rfc7578::client::{self, multipart};
-    /// use hyper::client::Client;
-    /// use tokio_core::reactor::{Core, Handle};
-    ///
-    /// # fn main() {
-    /// let core = Core::new().unwrap();
-    /// let client: Client<_, multipart::Body> = client::create(&core.handle());
-    /// # }
-    /// ```
-    ///
-    pub fn create(handle: &Handle) -> Client<HttpConnector, multipart::Body> {
-        Config::default().body::<multipart::Body>().build(handle)
     }
 }


### PR DESCRIPTION
Also updates Rand dependency, and moves from tokio-core to tokio for examples. It also uses Hyper's provided body type as a wrapper around the multipart body stream.