### PR TITLE
Add feature for using crate with actix-web

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,8 @@ rust:
   - stable
   - beta
   - nightly
+script:
+  - cargo build --verbose
+  - cargo build --verbose --features actix --no-default-features
+  - cargo test --verbose
+  - cargo test --verbose --features actix --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,18 @@ license           = "MIT OR Apache-2.0"
 [badges]
 travis-ci         = { repository = "ferristseng/rust-hyper-multipart-rfc7578" }
 
+[features]
+default           = ["hyper"]
+actix             = ["actix-web"]
+
 [dependencies]
 bytes             = "0.4"
 futures           = "0.1"
 http              = "0.1"
-hyper             = "0.12"
+hyper             = { version = "0.12", optional = true }
 mime              = "0.3"
 rand              = "0.5"
+actix-web         = { version = "0.7", optional = true }
 
 [dev-dependencies]
 hyper-tls         = "0.3"

--- a/examples/file.rs
+++ b/examples/file.rs
@@ -6,15 +6,24 @@
 // copied, modified, or distributed except according to those terms.
 //
 
+#[cfg(feature = "actix")]
+extern crate actix_web;
+extern crate futures;
+#[cfg(feature = "hyper")]
 extern crate hyper;
 extern crate hyper_multipart_rfc7578 as hyper_multipart;
 
-use hyper::{Client, Request, rt::{self, Future}};
+#[cfg(feature = "actix")]
+use actix_web::client;
+#[cfg(feature = "hyper")]
+use hyper::{rt, Client, Request};
+
+use futures::prelude::*;
+
 use hyper_multipart::client::multipart;
 
 fn main() {
     let addr = "http://127.0.0.1:9001";
-    let client = Client::builder().keep_alive(false).build_http();
 
     println!("note: this must be run in the root of the project repository");
     println!("note: run this with the example server running");
@@ -26,14 +35,26 @@ fn main() {
     form.add_file("input", file!())
         .expect("source file path should exist");
 
-    let mut req_builder = Request::post(addr);
+    #[cfg(feature = "hyper")]
+    {
+        let client = Client::builder().keep_alive(false).build_http();
+        let mut req_builder = Request::post(addr);
 
-    let req = form.set_body(&mut req_builder).unwrap();
-
-    rt::run(
-        client
-            .request(req)
+        let req = form.set_body(&mut req_builder).unwrap();
+        rt::run(
+            client
+                .request(req)
+                .map(|_| println!("done..."))
+                .map_err(|_| println!("an error occurred")),
+        );
+    };
+    #[cfg(feature = "actix")]
+    actix_web::actix::run(|| {
+        client::post("http://127.0.0.1:9001")
+            .streaming(multipart::Body::from(form))
+            .unwrap()
+            .send()
             .map(|_| println!("done..."))
-            .map_err(|_| println!("an error occurred")),
-    );
+            .map_err(|_| println!("an error occurred"))
+    });
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -6,15 +6,27 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-extern crate futures;
+#[cfg(feature = "actix")]
+extern crate actix_web;
+
 extern crate http;
+#[cfg(feature = "hyper")]
 extern crate hyper;
 
-use futures::{Future, Stream};
-use hyper::{Body, Request, Response, Server, service::service_fn};
+extern crate futures;
 
+#[cfg(feature = "actix")]
+use actix_web::{server, App, HttpMessage, HttpRequest, HttpResponse};
+
+#[cfg(feature = "hyper")]
+use hyper::{service::service_fn, Body, Request, Response, Server};
+
+use futures::prelude::*;
+
+#[cfg(feature = "hyper")]
 type BoxFut = Box<Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 
+#[cfg(feature = "hyper")]
 fn index(req: Request<Body>) -> BoxFut {
     let res = req.into_body().concat2().map(|bod| {
         println!("{}", String::from_utf8_lossy(&bod));
@@ -25,14 +37,26 @@ fn index(req: Request<Body>) -> BoxFut {
     Box::new(res)
 }
 
+#[cfg(feature = "actix")]
+fn index(req: HttpRequest) -> HttpResponse {
+    HttpResponse::Ok().streaming(req.payload())
+}
 /// This example runs a server that prints requests as it receives them.
 /// It is useful for debugging.
 ///
 fn main() {
-    let addr = "127.0.0.1:9001".parse().unwrap();
-    let server = Server::bind(&addr)
-        .serve(|| service_fn(index))
-        .map_err(|e| eprintln!("{}", e));
+    let addr = "127.0.0.1:9001";
+    #[cfg(feature = "hyper")]
+    {
+        let server = Server::bind(&addr.parse().unwrap())
+            .serve(|| service_fn(index))
+            .map_err(|e| eprintln!("{}", e));
 
-    hyper::rt::run(server);
+        hyper::rt::run(server);
+    };
+    #[cfg(feature = "actix")]
+    server::new(|| App::new().resource("/", |r| r.with(index)))
+        .bind(addr)
+        .unwrap()
+        .run();
 }

--- a/src/client_.rs
+++ b/src/client_.rs
@@ -7,14 +7,27 @@
 //
 
 use bytes::{BufMut, Bytes, BytesMut, IntoBuf};
-use futures::{Async, Poll, stream::Stream};
-use http::{self, header::CONTENT_DISPOSITION, header::CONTENT_TYPE, request::{Builder, Request}};
+use futures::{stream::Stream, Async, Poll};
+use http::{
+    self,
+    header::CONTENT_DISPOSITION,
+    header::CONTENT_TYPE,
+    request::{Builder, Request},
+};
+#[cfg(feature = "hyper")]
 use hyper::{self, body::Payload};
 use mime::{self, Mime};
-use rand::{FromEntropy, Rng, distributions::Alphanumeric, rngs::SmallRng};
+use rand::{distributions::Alphanumeric, rngs::SmallRng, FromEntropy, Rng};
 use std::borrow::Borrow;
-use std::{fmt::Display, fs::File, io::{self, Cursor, Read, Write}, iter::{FromIterator, Peekable},
-          path::Path, str::FromStr, vec::IntoIter};
+use std::{
+    fmt::Display,
+    fs::File,
+    io::{self, Cursor, Read, Write},
+    iter::{FromIterator, Peekable},
+    path::Path,
+    str::FromStr,
+    vec::IntoIter,
+};
 
 use error::Error;
 
@@ -127,7 +140,9 @@ impl<'a> Stream for Body<'a> {
         let num = if let Some(ref mut read) = self.current {
             let mut buf = writer.get_mut();
             unsafe {
-                let num = read.read(&mut buf.bytes_mut()).map_err(Error::ContentRead)?;
+                let num = read
+                    .read(&mut buf.bytes_mut())
+                    .map_err(Error::ContentRead)?;
 
                 buf.advance_mut(num);
 
@@ -160,6 +175,7 @@ impl<'a> Stream for Body<'a> {
     }
 }
 
+#[cfg(feature = "hyper")]
 impl Payload for Body<'static> {
     type Data = Cursor<Bytes>;
 
@@ -343,7 +359,6 @@ impl<'a> Form<'a> {
     /// # Examples
     ///
     /// ```
-    /// # extern crate hyper;
     /// # extern crate mime;
     /// # extern crate hyper_multipart_rfc7578;
     /// #
@@ -381,7 +396,6 @@ impl<'a> Form<'a> {
     /// # Examples
     ///
     /// ```
-    /// # extern crate hyper;
     /// # extern crate mime;
     /// # extern crate hyper_multipart_rfc7578;
     /// #
@@ -472,6 +486,7 @@ impl Form<'static> {
     /// # }
     /// ```
     ///
+    #[cfg(feature = "hyper")]
     pub fn set_body(self, req: &mut Builder) -> Result<Request<hyper::Body>, http::Error> {
         let header = format!("multipart/form-data; boundary=\"{}\"", &self.boundary);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use std::{fmt, error::Error as StdError, io::Error as IoError};
+use std::{error::Error as StdError, fmt, io::Error as IoError};
+
+#[cfg(feature = "actix")]
+use actix_web::{error::ResponseError, http::StatusCode, HttpResponse};
 
 #[derive(Debug)]
 pub enum Error {
@@ -39,6 +42,15 @@ impl StdError for Error {
             Error::HeaderWrite(ref e) => Some(e),
             Error::BoundaryWrite(ref e) => Some(e),
             Error::ContentRead(ref e) => Some(e),
+        }
+    }
+}
+
+#[cfg(feature = "actix")]
+impl ResponseError for Error {
+    fn error_response(&self) -> HttpResponse {
+        match *self {
+            _ => HttpResponse::new(StatusCode::INTERNAL_SERVER_ERROR),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@
 //! hyper.
 //!
 //! Currently, only the client-side is implemented.
-//!
 //! ## Usage
 //!
 //! ```toml
@@ -27,34 +26,67 @@
 //!
 //! Using this requires a hyper client compatible with the `multipart::Body`
 //! data structure (see the documentation for more detailed examples):
-//!
-//! ```rust
-//! # extern crate hyper;
-//! # extern crate hyper_multipart_rfc7578;
-//!
-//! use hyper::{Client, Request, rt::{self, Future}};
-//! use hyper_multipart_rfc7578::client::{self, multipart};
-//!
-//! # fn main() {
-//! let client = Client::new();
-//! let mut req_builder = Request::get("http://localhost/upload");
-//! let mut form = multipart::Form::default();
-//!
-//! form.add_text("test", "Hello World");
-//! let req = form.set_body(&mut req_builder).unwrap();
-//!
-//! rt::run(
-//!     client
-//!         .request(req)
-//!         .map(|_| println!("done..."))
-//!         .map_err(|_| println!("an error occurred")),
-//! );
-//! # }
-//! ```
-//!
+
+
+/// ### With Actix
+///
+/// ```rust
+/// # extern crate actix_web;
+/// # extern crate futures;
+/// # extern crate hyper_multipart_rfc7578;
+///
+/// use futures::prelude::*;
+/// use hyper_multipart_rfc7578::client::{self, multipart};
+///
+/// # fn main() {
+/// let mut form = multipart::Form::default();
+///
+/// form.add_text("test", "Hello World");
+/// actix_web::actix::run(|| {
+///     actix_web::client::get("http://localhost/upload")
+///         .streaming(multipart::Body::from(form))
+///         .unwrap()
+///         .send()
+///         .map(|_| println!("done..."))
+///         .map_err(|_| println!("an error occurred"))
+///         .then(|_| { actix_web::actix::System::current().stop(); Ok(()) })
+/// });
+/// # }
+/// ```
+#[cfg(feature = "actix")]
+extern crate actix_web;
 extern crate bytes;
 extern crate futures;
 extern crate http;
+
+/// ### With Hyper
+///
+/// ```rust
+/// # extern crate futures;
+/// # extern crate hyper;
+/// # extern crate hyper_multipart_rfc7578;
+///
+/// use futures::prelude::*;
+/// use hyper::{Client, Request, rt::{self, Future}};
+/// use hyper_multipart_rfc7578::client::{self, multipart};
+///
+/// # fn main() {
+/// let mut form = multipart::Form::default();
+///
+/// form.add_text("test", "Hello World");
+/// let client = Client::new();
+/// let mut req_builder = Request::get("http://localhost/upload");
+/// let req = form.set_body(&mut req_builder).unwrap();
+///
+/// rt::run(
+///     client
+///         .request(req)
+///         .map(|_| println!("done..."))
+///         .map_err(|_| println!("an error occurred")),
+/// );
+/// # }
+/// ```
+#[cfg(feature = "hyper")]
 extern crate hyper;
 extern crate mime;
 extern crate rand;


### PR DESCRIPTION
This PR adds `actix` a feature for using the crate with actix-web.

It can be used with `hyper-multipart-rfc7578 = { version = "theversion", default-features = false, features = ["actix"] }` in `Cargo.toml`.

Examples and docs have been updated to compile with the actix feature.

This is part of an effort to make [rust-ipfs-api](https://github.com/ferristseng/rust-ipfs-api/) work with actix-web so I can use it in [git-lfs-ipfs](https://github.com/sameer/git-lfs-ipfs) and merge any new stuff I implemented back into `rust-ipfs-api`.