### PR TITLE
Expose content_type for setting content_type in actix-web

### DIFF
--- a/actix/examples/actix-file.rs
+++ b/actix/examples/actix-file.rs
@@ -24,6 +24,7 @@ fn main() {
 
     actix_web::actix::run(|| {
         client::post(addr)
+            .content_type(form.content_type())
             .streaming(multipart::Body::from(form))
             .unwrap()
             .send()

--- a/actix/src/lib.rs
+++ b/actix/src/lib.rs
@@ -42,6 +42,7 @@
 //!
 //! actix_web::actix::run(|| {
 //!     actix_web::client::get("http://localhost/upload")
+//!         .content_type(form.content_type())
 //!         .streaming(multipart::Body::from(form))
 //!         .unwrap()
 //!         .send()

--- a/common/src/client_.rs
+++ b/common/src/client_.rs
@@ -491,13 +491,13 @@ impl<'a> Form<'a> {
     where
         I: From<Body<'a>> + Into<B>,
     {
-        let header = format!("multipart/form-data; boundary=\"{}\"", &self.boundary);
-
-        let header: &str = header.as_ref();
-
-        req.header(CONTENT_TYPE, header);
+        req.header(CONTENT_TYPE, self.content_type().as_str());
 
         req.body(I::from(Body::from(self)).into())
+    }
+
+    pub fn content_type(&self) -> String {
+        format!("multipart/form-data; boundary=\"{}\"", &self.boundary)
     }
 }
 


### PR DESCRIPTION
I missed setting the content-type in the Actix example.

Interestingly, Actix-web's [ClientRequestBuilder](https://docs.rs/actix-web/0.7.18/actix_web/client/struct.ClientRequestBuilder.html) implements almost the exact same methods as http's [Builder](https://docs.rs/http/0.1.15/http/request/struct.Builder.html#method.header) but doesn't support conversion, so neither `set_body` nor `set_body_convert` can be used.

To fix this, I exposed the content_type so actix-web users set it manually. I didn't see another way to do this in the common crate without having an `extern actix_web`.