### PR TITLE
Implement Into<IoError> for Error

### DIFF
--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -20,3 +20,13 @@ pub enum Error {
     #[error("Failed to write multipart content: {0:?}")]
     ContentRead(IoError),
 }
+
+impl Into<IoError> for Error {
+    fn into(self) -> IoError {
+        match self {
+            Error::HeaderWrite(io) => io,
+            Error::BoundaryWrite(io) => io,
+            Error::ContentRead(io) => io
+        }
+    }
+}


### PR DESCRIPTION
This helps with using the Body with [`tokio_util::io::StreamReader`](https://docs.rs/tokio-util/latest/tokio_util/io/struct.StreamReader.html) which requires the error to be convertible into an io error.