### PR TITLE
Fix final boundary after each part

### DIFF
--- a/common/src/client_.rs
+++ b/common/src/client_.rs
@@ -145,7 +145,10 @@ impl<'a> Stream for Body<'a> {
                     Ok(0) => {
                         body.current = None;
 
-                        body.write_final_boundary();
+                        if self.parts.peek().is_none() {
+                            // If we reached the last part of the form, write the final boundary
+                            body.write_final_boundary();
+                        }
 
                         Poll::Ready(Some(Ok(body.buf.split())))
                     }


### PR DESCRIPTION
This crate writes the final boundary of the form after each part, instead of once after the final part.

So for instance if multiple parts are written in the body, this lib emit the following body

```
content-type: multipart/form-data; boundary=abc

--abc
content-type: text/plain
content-disposition: form-data; name="part1"

value1
--abc--
--abc
content-type: text/plain
content-disposition: form-data; name="part2"

value2
--abc--
```

When it should be

```
content-type: multipart/form-data; boundary=abc

--abc
content-type: text/plain
content-disposition: form-data; name="part1"

value1
--abc
content-type: text/plain
content-disposition: form-data; name="part2"

value2
--abc--
```