### PR TITLE
Fixes to the form format

### DIFF
--- a/common/src/client_.rs
+++ b/common/src/client_.rs
@@ -145,7 +145,10 @@ impl<'a> Stream for Body<'a> {
                     Ok(0) => {
                         body.current = None;
 
-                        body.write_final_boundary();
+                        if self.parts.peek().is_none() {
+                            // If we reached the last part of the form, write the final boundary
+                            body.write_final_boundary();
+                        }
 
                         Poll::Ready(Some(Ok(body.buf.split())))
                     }


### PR DESCRIPTION
Hey, I want to use this crate but I found bugs in the way forms with multiple parts are sent, which I addressed in 3 commits.

# First commit 
This adresses the fact that the final boundary was writtten after every part instead of once at the end

This crate writes the final boundary of the form after each part, instead of once after the final part.

So for instance if multiple parts are written in the body, this lib emit the following body

```
content-type: multipart/form-data; boundary=abc

--abc
content-type: text/plain
content-disposition: form-data; name="part1"

value1
--abc--
--abc
content-type: text/plain
content-disposition: form-data; name="part2"

value2
--abc--
```

When it should be

```
content-type: multipart/form-data; boundary=abc

--abc
content-type: text/plain
content-disposition: form-data; name="part1"

value1
--abc
content-type: text/plain
content-disposition: form-data; name="part2"

value2
--abc--
```

# Second commit

Fix an unsafety

```
let uninit_chunk = std::ptr::slice_from_raw_parts_mut(
    uninit_chunk.as_mut_ptr(),
    uninit_chunk.len(),
);

// Safe because chunk_mut() returns an array of uninitialized bytes, we are
// transforming it into something that can be passed to poll_read.
let uninit_chunk = unsafe { uninit_chunk.as_mut().unwrap() };
```

This is unsafe, you're getting uninit memory from the BytesMut and casting it to an `&mut [u8]`. This is undefined behaviour in every case https://doc.rust-lang.org/std/mem/fn.uninitialized.html .

Instead I first zero the remaining capacity in the buffer, get a mut slice to it, and restore the slice of the BytesMut to the length that had been read.
The zeroing is a bit more expensive than taking uninit memory, but there is no safe way around it.
This also has the advantage of removing every `unsafe` occurence from this crate.

 # Third commit

Remove the trailing CRLF which isn't required, and adds a test to verify that the format is spec compliant and that the stream implementation works correctly for multiple parts.