### PR TITLE
Multipart format fixes: header boundary parameter and final CRLF

### DIFF
--- a/common/src/client_.rs
+++ b/common/src/client_.rs
@@ -565,7 +565,7 @@ impl<'a> Form<'a> {
     }
 
     pub fn content_type(&self) -> String {
-        format!("multipart/form-data; boundary=\"{}\"", &self.boundary)
+        format!("multipart/form-data; boundary={}", &self.boundary)
     }
 }
 
@@ -756,14 +756,15 @@ mod tests {
         assert!(data.contains("text/csv"));
     }
 
+    struct FixedBoundary;
+    impl crate::boundary::BoundaryGenerator for FixedBoundary {
+        fn generate_boundary() -> String {
+            "boundary".to_owned()
+        }
+    }
+
     #[tokio::test]
     async fn test_form_body_stream() {
-        struct FixedBoundary;
-        impl crate::boundary::BoundaryGenerator for FixedBoundary {
-            fn generate_boundary() -> String {
-                "boundary".to_owned()
-            }
-        }
         let mut form = Form::new::<FixedBoundary>();
         // Text fields
         form.add_text("name1", "value1");
@@ -793,7 +794,29 @@ mod tests {
                 b"\r\n".as_ref(),
                 b"Hello World!\r\n".as_ref(),
                 b"--boundary--\r\n".as_ref(),
-            ].into_iter().flatten().copied().collect::<Vec<u8>>()
+            ]
+            .into_iter()
+            .flatten()
+            .copied()
+            .collect::<Vec<u8>>()
         );
+    }
+
+    #[tokio::test]
+    async fn test_content_type_header_format() {
+        use http::Request;
+
+        let mut form = Form::new::<FixedBoundary>();
+        // Text fields
+        form.add_text("name1", "value1");
+        form.add_text("name2", "value2");
+
+        let builder = Request::builder();
+        let body = form.set_body::<Body>(builder).unwrap();
+
+        assert_eq!(
+            body.headers().get("Content-Type").unwrap().as_bytes(),
+            b"multipart/form-data; boundary=boundary",
+        )
     }
 }

--- a/common/src/client_.rs
+++ b/common/src/client_.rs
@@ -148,6 +148,7 @@ impl<'a> Stream for Body<'a> {
                             if body.parts.peek().is_none() {
                                 // If there is no next part, write the final boundary
                                 body.write_final_boundary();
+                                body.write_crlf();
                             }
                         }
 
@@ -791,7 +792,7 @@ mod tests {
                 b"content-disposition: form-data; name=\"input\"\r\n".as_ref(),
                 b"\r\n".as_ref(),
                 b"Hello World!\r\n".as_ref(),
-                b"--boundary--".as_ref(),
+                b"--boundary--\r\n".as_ref(),
             ].into_iter().flatten().copied().collect::<Vec<u8>>()
         );
     }


### PR DESCRIPTION
Hello, it's me again, thank you for merging my last PR quickly and releasing a new version 👍

I noticed two more problems:

* A final CRLF is usually added after the final boundary. According tio the spec, it's not strictly necessary but most implementations I looked at added it.
* The Content-type header boundary parameter shouldn't be quoted https://datatracker.ietf.org/doc/html/rfc2046#section-5.1.1

Also, I didn't address this in this PR, but if you bump the minor version and release the crate, I would recommend specifying the full semver version in the hyper and actix `Cargo.toml`

For instance `hyper/Cargo.toml` should have

```toml
common-multipart-rfc7578  = { path = "../common", version = "0.4.2" }
```

Instead of 

```toml
common-multipart-rfc7578  = { path = "../common", version = "0.4" }
```

Because otherwise, users that upgrade hyper-multipart-rfc7578 from `0.6` to `0.6.2` will not also pull the newer version of `common-multipart-rfc7578` if they already have the `0.4.1` version in cache.